### PR TITLE
fix(examples): use pph_size_t for loop to avoid warning

### DIFF
--- a/examples/example_250m_with_bonuses.c
+++ b/examples/example_250m_with_bonuses.c
@@ -14,7 +14,7 @@ int main(void) {
     pph21_input_t input = {0};
     pph_result_t *result;
     char buffer[64];
-    int i;
+    pph_size_t i;
 
     /* Define bonuses */
     pph21_bonus_t bonuses[] = {


### PR DESCRIPTION
switch loop index to pph_size_t to eliminate sign-compare warnings.